### PR TITLE
Windows supports "\" and "/" as path separators, Linux not, so use "/"

### DIFF
--- a/src/DigitLedDisplay.h
+++ b/src/DigitLedDisplay.h
@@ -2,7 +2,7 @@
 #define DigitLedDisplay_h
 
 #if (defined(__AVR__))
-#include <avr\pgmspace.h>
+#include <avr/pgmspace.h>
 #else
 #include <pgmspace.h>
 #endif


### PR DESCRIPTION
This is necessary for the library to compile on Linux systems.

Cherry picked from @Hermann-SW's fork.