### PR TITLE
Fixes build for unix

### DIFF
--- a/src/DigitLedDisplay.h
+++ b/src/DigitLedDisplay.h
@@ -2,7 +2,7 @@
 #define DigitLedDisplay_h
 
 #if (defined(__AVR__))
-#include <avr\pgmspace.h>
+#include <avr/pgmspace.h>
 #else
 #include <pgmspace.h>
 #endif


### PR DESCRIPTION
Unix only understands forward slash for directories.  Windows understands both forward slash and backward slash.