### PR TITLE
Option to use much faster Hardware SPI instead of shiftOut

### DIFF
--- a/src/DigitLedDisplay.h
+++ b/src/DigitLedDisplay.h
@@ -2,7 +2,7 @@
 #define DigitLedDisplay_h
 
 #if (defined(__AVR__))
-#include <avr\pgmspace.h>
+#include <avr/pgmspace.h>
 #else
 #include <pgmspace.h>
 #endif

--- a/src/DigitLedDisplay.h
+++ b/src/DigitLedDisplay.h
@@ -26,7 +26,7 @@ class DigitLedDisplay
 		int _digitLimit;
 		void table(byte address, int val);	
 	public:
-		DigitLedDisplay(int dinPin, int csPin, int clkPin);
+		DigitLedDisplay(int dinPin, int csPin, int clkPin, bool useHardwareSPI = false);
 		void setBright(int brightness);
 		void setDigitLimit(int limit);
 		void printDigit(long number, byte startDigit = 0);


### PR DESCRIPTION
Measuring on my 16 Mhz Trinket Pro with a MAX7219, a full 8-digit clear takes only 124 to 132 microseconds now with Hardware SPI, instead of 1656 to 1664 microseconds with shiftOut.  That is over 13x speedup.

to initiate with hardware spi, use the same constructor but append an additional parameter of useHardwareSPI = true, otherwise that parameter will default to false.  useHardwareSPI will ignores the pass dinPin and clkPin parameters, and instead set those internally to USE_HW_SPI which is defined as 255 (which is the same definition used in AdaFruit's DotStar library: https://github.com/adafruit/Adafruit_DotStar/blob/master/Adafruit_DotStar.cpp#L47).